### PR TITLE
#166760013 Fix typo error on login

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -66,7 +66,7 @@ class Users {
     if (!user || !encrypt.comparePassword(user.get().password, body.password)) {
       return res.status(401).json({
         status: 401,
-        message: 'The credentials you provided is incorrect',
+        message: 'The credentials you provided are incorrect',
       });
     } if (user.isDisabled) {
       return res.status(403).json({

--- a/server/test/user.test.js
+++ b/server/test/user.test.js
@@ -146,7 +146,7 @@ describe('User ', () => {
         .end((err, res) => {
           expect(res.status).to.equal(401);
           expect(res).to.be.an('object');
-          expect(res.body.message).to.equal('The credentials you provided is incorrect');
+          expect(res.body.message).to.equal('The credentials you provided are incorrect');
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
• Fix a typo error when providing the wrong credentials

#### Description of Task to be completed?
• change the error message when the login was not successful 

#### How should this be manually tested?
go to `/login` provide the email and the password

#### Any background context you want to provide?
• previously the error had a grammatical mistake

#### What are the relevant pivotal tracker stories?
[#166760013](https://www.pivotaltracker.com/story/show/166760013)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/27511264/59677603-87d7d100-91ca-11e9-9ea0-ff3637968be9.png)

#### Questions:
N/A