### PR TITLE
#166796298 Refactor profile update to update more fields

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,11 @@
     "consistent-return": 0,
     "no-param-reassign": 0,
     "comma-dangle": 0,
-    "curly": ["error", "multi-line"],
+    "eact/no-string-refs": 0,
+    "curly": [
+      "error",
+      "multi-line"
+    ],
     "import/no-unresolved": [
       2,
       {
@@ -21,7 +25,7 @@
       }
     ],
     "import/no-extraneous-dependencies": [
-      "error", 
+      "error",
       {
         "devDependencies": true
       }
@@ -29,7 +33,11 @@
     "no-shadow": [
       "error",
       {
-        "allow": ["req", "res", "err"]
+        "allow": [
+          "req",
+          "res",
+          "err"
+        ]
       }
     ],
     "valid-jsdoc": [

--- a/server/config/constant.js
+++ b/server/config/constant.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/prefer-default-export */
+
 export const LOCAL_PORT = 3000;
 export const defaultRoles = {
   USER: 'user',

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -1,6 +1,8 @@
 import dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
-import { User, Role, Following, Article } from '../models/index';
+import {
+  User, Role, Following, Article
+} from '../models/index';
 import encrypt from '../helpers/encrypt';
 import sendMail from '../helpers/sendVerificationEmail';
 import errorHandler from '../helpers/errorHandler';
@@ -212,13 +214,17 @@ class Users {
     try {
       const { username } = req.params;
       const {
-        email, bio, image
-      } = req.body;
+        body
+      } = req;
+      const { email } = req.user;
+      const { email: newEmail = '' } = body;
+      if (newEmail.length > 0 && newEmail !== email) {
+        body.verified = false;
+        body.isLoggedIn = false;
+      }
       const result = await User.update(
         {
-          email,
-          bio,
-          image,
+          ...body,
         },
         {
           where: { username },

--- a/server/test/config/users.js
+++ b/server/test/config/users.js
@@ -23,6 +23,11 @@ const users = {
     email: 'hadad_test@andela.com',
     password: 'Hadad12@'
   },
+  correct1: {
+    username: 'dusmel5',
+    email: 'hadad_test5@andela.com',
+    password: 'Hadad12@'
+  },
   correctUserForComment: {
     username: 'karl122',
     email: 'karl_test_comment@andela.com',
@@ -39,6 +44,10 @@ const users = {
   },
   correctLogInfo: {
     email: 'hadad_test@andela.com',
+    password: 'Hadad12@'
+  },
+  correctLogInfo1: {
+    email: 'hadad_test5@andela.com',
     password: 'Hadad12@'
   },
   correctLikeArticle: {

--- a/server/test/user.test.js
+++ b/server/test/user.test.js
@@ -162,29 +162,6 @@ describe('User ', () => {
           done();
         });
     });
-
-    // Profile updating test
-
-    const user = {
-      email: 'gisele.iradukunda@andela.com',
-      bio: 'I am not afraid',
-      image: 'https://image.jpg'
-    };
-    it('Should update user information', (done) => {
-      chai.request(app)
-        .put(`/api/user/${dummyUsers.correct.username}`)
-        .set('Authorization', userToken)
-        .send(user)
-        .end((error, res) => {
-          expect(res.body.status).to.be.equal(200);
-          expect(res.body).to.have.property('user');
-          expect(res.body.user).to.have.property('email');
-          expect(res.body.user).to.have.property('bio');
-          expect(res.body.user).to.have.property('image');
-          expect(res.body.user.image).equals('https://image.jpg');
-          done();
-        });
-    });
     // View own Profile or Display user info
     it('Should display user information', (done) => {
       chai.request(app)
@@ -202,16 +179,15 @@ describe('User ', () => {
           expect(res.body.profile).to.have.property('follows');
           expect(res.body.profile).to.have.property('followings');
           expect(res.body.profile).to.have.property('articles');
-          expect(res.body.profile.email).equals('gisele.iradukunda@andela.com');
-          expect(res.body.profile.bio).equals('I am not afraid');
-          expect(res.body.profile.image).equals('https://image.jpg');
+          expect(res.body.profile.email).equals('hadad_test@andela.com');
+          expect(res.body.profile.bio).equals(null);
+          expect(res.body.profile.image).equals(null);
           done();
         });
     });
   });
 
   // Following a user
-
 
   describe('User', () => {
     describe('Following', () => {
@@ -314,6 +290,41 @@ describe('User ', () => {
             done();
           });
       });
+    });
+  });
+  describe('Profile Update', () => {
+    it('should be able to signup', (done) => {
+      chai.request(app)
+        .post('/api/auth/signup')
+        .send(dummyUsers.correct1)
+        .end((err, res) => {
+          userToken = `Bearer ${res.body.user.token}`;
+          expect(res.status).to.equal(200);
+          expect(res).to.be.an('object');
+          expect(res.body).to.have.property('user');
+          done();
+        });
+    });
+    // Profile updating test
+    const user = {
+      email: 'gisele.iradukunda@andela.com',
+      bio: 'I am not afraid',
+      image: 'https://image.jpg'
+    };
+    it('Should update user information', (done) => {
+      chai.request(app)
+        .put(`/api/user/${dummyUsers.correct.username}`)
+        .set('Authorization', userToken)
+        .send(user)
+        .end((error, res) => {
+          expect(res.body.status).to.be.equal(200);
+          expect(res.body).to.have.property('user');
+          expect(res.body.user).to.have.property('email');
+          expect(res.body.user).to.have.property('bio');
+          expect(res.body.user).to.have.property('image');
+          expect(res.body.user.image).equals('https://image.jpg');
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- Adds more fields to update in the user profile

#### Description of Task to be completed?

- User should provide the fields as shown from the front-end 

- It is only applicable for the logged in user

#### How should this be manually tested?

-  Through```http://localhost:3000/api/user/girad4```

#### Any background context you want to provide?
It fixes the exiting feature of updating the user profile 
#### What are the relevant pivotal tracker stories?

- [#166796298](https://www.pivotaltracker.com/story/show/166796298)

#### Screenshots (if appropriate)

- The body to pass
<img width="1121" alt="Screen Shot 2019-06-19 at 17 23 30" src="https://user-images.githubusercontent.com/38489632/59778665-36594000-92b7-11e9-92c4-ef8af70659e4.png">

#### Questions:
N/A